### PR TITLE
Show pairings and results in same order as chess results

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta http-equiv="Content-Security-Policy" content="connect-src 'self' lichess.org corsproxy.io;" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="connect-src 'self' lichess.org lichess.dev corsproxy.io;"
+    />
 
     <link href="/api/ui/style.min.css" rel="stylesheet" />
     <link rel="icon" type="image/x-icon" href="/api/ui/favicon.ico" />

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="connect-src 'self' l.org localhost:8080 lichess.org corsproxy.io;"
+      content="connect-src 'self' l.org localhost:8080 lichess.org lichess.dev corsproxy.io;"
     />
 
     <link href="style.css" rel="stylesheet" />

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^11.1.6",
     "@types/cheerio": "^0.22.35",
-    "@types/node": "^20.11.6",
+    "@types/node": "^20.11.8",
     "@types/page": "^1.11.9",
     "http-server": "^14.1.1",
     "jsdom": "^24.0.0",
@@ -25,7 +25,7 @@
     "sass": "~1.70.0",
     "tslib": "~2.6.2",
     "typescript": "~5.3.3",
-    "vitest": "^1.2.1"
+    "vitest": "^1.2.2"
   },
   "scripts": {
     "build": "rollup --config",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,8 +38,8 @@ devDependencies:
     specifier: ^0.22.35
     version: 0.22.35
   '@types/node':
-    specifier: ^20.11.6
-    version: 20.11.6
+    specifier: ^20.11.8
+    version: 20.11.8
   '@types/page':
     specifier: ^1.11.9
     version: 1.11.9
@@ -68,8 +68,8 @@ devDependencies:
     specifier: ~5.3.3
     version: 5.3.3
   vitest:
-    specifier: ^1.2.1
-    version: 1.2.1(@types/node@20.11.6)(jsdom@24.0.0)(sass@1.70.0)
+    specifier: ^1.2.2
+    version: 1.2.2(@types/node@20.11.8)(jsdom@24.0.0)(sass@1.70.0)
 
 packages:
 
@@ -529,15 +529,15 @@ packages:
   /@types/cheerio@0.22.35:
     resolution: {integrity: sha512-yD57BchKRvTV+JD53UZ6PD8KWY5g5rvvMLRnZR3EQBCZXiDT/HR+pKpMzFGlWNhFrXlo7VPZXtKvIEwZkAWOIA==}
     dependencies:
-      '@types/node': 20.11.6
+      '@types/node': 20.11.8
     dev: true
 
   /@types/estree@1.0.5:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
     dev: true
 
-  /@types/node@20.11.6:
-    resolution: {integrity: sha512-+EOokTnksGVgip2PbYbr3xnR7kZigh4LbybAfBAw5BpnQ+FqBYUsvCEjYd70IXKlbohQ64mzEYmMtlWUY8q//Q==}
+  /@types/node@20.11.8:
+    resolution: {integrity: sha512-i7omyekpPTNdv4Jb/Rgqg0RU8YqLcNsI12quKSDkRXNfx7Wxdm6HhK1awT3xTgEkgxPn3bvnSpiEAc7a7Lpyow==}
     dependencies:
       undici-types: 5.26.5
     dev: true
@@ -550,38 +550,38 @@ packages:
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
     dev: true
 
-  /@vitest/expect@1.2.1:
-    resolution: {integrity: sha512-/bqGXcHfyKgFWYwIgFr1QYDaR9e64pRKxgBNWNXPefPFRhgm+K3+a/dS0cUGEreWngets3dlr8w8SBRw2fCfFQ==}
+  /@vitest/expect@1.2.2:
+    resolution: {integrity: sha512-3jpcdPAD7LwHUUiT2pZTj2U82I2Tcgg2oVPvKxhn6mDI2On6tfvPQTjAI4628GUGDZrCm4Zna9iQHm5cEexOAg==}
     dependencies:
-      '@vitest/spy': 1.2.1
-      '@vitest/utils': 1.2.1
+      '@vitest/spy': 1.2.2
+      '@vitest/utils': 1.2.2
       chai: 4.4.1
     dev: true
 
-  /@vitest/runner@1.2.1:
-    resolution: {integrity: sha512-zc2dP5LQpzNzbpaBt7OeYAvmIsRS1KpZQw4G3WM/yqSV1cQKNKwLGmnm79GyZZjMhQGlRcSFMImLjZaUQvNVZQ==}
+  /@vitest/runner@1.2.2:
+    resolution: {integrity: sha512-JctG7QZ4LSDXr5CsUweFgcpEvrcxOV1Gft7uHrvkQ+fsAVylmWQvnaAr/HDp3LAH1fztGMQZugIheTWjaGzYIg==}
     dependencies:
-      '@vitest/utils': 1.2.1
+      '@vitest/utils': 1.2.2
       p-limit: 5.0.0
       pathe: 1.1.2
     dev: true
 
-  /@vitest/snapshot@1.2.1:
-    resolution: {integrity: sha512-Tmp/IcYEemKaqAYCS08sh0vORLJkMr0NRV76Gl8sHGxXT5151cITJCET20063wk0Yr/1koQ6dnmP6eEqezmd/Q==}
+  /@vitest/snapshot@1.2.2:
+    resolution: {integrity: sha512-SmGY4saEw1+bwE1th6S/cZmPxz/Q4JWsl7LvbQIky2tKE35US4gd0Mjzqfr84/4OD0tikGWaWdMja/nWL5NIPA==}
     dependencies:
       magic-string: 0.30.5
       pathe: 1.1.2
       pretty-format: 29.7.0
     dev: true
 
-  /@vitest/spy@1.2.1:
-    resolution: {integrity: sha512-vG3a/b7INKH7L49Lbp0IWrG6sw9j4waWAucwnksPB1r1FTJgV7nkBByd9ufzu6VWya/QTvQW4V9FShZbZIB2UQ==}
+  /@vitest/spy@1.2.2:
+    resolution: {integrity: sha512-k9Gcahssw8d7X3pSLq3e3XEu/0L78mUkCjivUqCQeXJm9clfXR/Td8+AP+VC1O6fKPIDLcHDTAmBOINVuv6+7g==}
     dependencies:
       tinyspy: 2.2.0
     dev: true
 
-  /@vitest/utils@1.2.1:
-    resolution: {integrity: sha512-bsH6WVZYe/J2v3+81M5LDU8kW76xWObKIURpPrOXm2pjBniBu2MERI/XP60GpS4PHU3jyK50LUutOwrx4CyHUg==}
+  /@vitest/utils@1.2.2:
+    resolution: {integrity: sha512-WKITBHLsBHlpjnDQahr+XK6RE7MiAsgrIkr0pGhQ9ygoxBfUeG0lUG5iLlzqjmKSlBv3+j5EGsriBzh+C3Tq9g==}
     dependencies:
       diff-sequences: 29.6.3
       estree-walker: 3.0.3
@@ -1201,8 +1201,8 @@ packages:
       safer-buffer: 2.1.2
     dev: true
 
-  /immutable@4.3.4:
-    resolution: {integrity: sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==}
+  /immutable@4.3.5:
+    resolution: {integrity: sha512-8eabxkth9gZatlwl5TBuJnCsoTADlL6ftEr7A4qgdaTsPyreilDSnUk57SO+jfKcNtxPa22U5KK6DSeAYhpBJw==}
     dev: true
 
   /inflight@1.0.6:
@@ -1669,7 +1669,7 @@ packages:
     hasBin: true
     dependencies:
       chokidar: 3.5.3
-      immutable: 4.3.4
+      immutable: 4.3.5
       source-map-js: 1.0.2
     dev: true
 
@@ -1886,8 +1886,8 @@ packages:
       requires-port: 1.0.0
     dev: true
 
-  /vite-node@1.2.1(@types/node@20.11.6)(sass@1.70.0):
-    resolution: {integrity: sha512-fNzHmQUSOY+y30naohBvSW7pPn/xn3Ib/uqm+5wAJQJiqQsU0NBR78XdRJb04l4bOFKjpTWld0XAfkKlrDbySg==}
+  /vite-node@1.2.2(@types/node@20.11.8)(sass@1.70.0):
+    resolution: {integrity: sha512-1as4rDTgVWJO3n1uHmUYqq7nsFgINQ9u+mRcXpjeOMJUmviqNKjcZB7UfRZrlM7MjYXMKpuWp5oGkjaFLnjawg==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     dependencies:
@@ -1895,7 +1895,7 @@ packages:
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.0.12(@types/node@20.11.6)(sass@1.70.0)
+      vite: 5.0.12(@types/node@20.11.8)(sass@1.70.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -1907,7 +1907,7 @@ packages:
       - terser
     dev: true
 
-  /vite@5.0.12(@types/node@20.11.6)(sass@1.70.0):
+  /vite@5.0.12(@types/node@20.11.8)(sass@1.70.0):
     resolution: {integrity: sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -1935,7 +1935,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 20.11.6
+      '@types/node': 20.11.8
       esbuild: 0.19.12
       postcss: 8.4.33
       rollup: 4.9.6
@@ -1944,8 +1944,8 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@1.2.1(@types/node@20.11.6)(jsdom@24.0.0)(sass@1.70.0):
-    resolution: {integrity: sha512-TRph8N8rnSDa5M2wKWJCMnztCZS9cDcgVTQ6tsTFTG/odHJ4l5yNVqvbeDJYJRZ6is3uxaEpFs8LL6QM+YFSdA==}
+  /vitest@1.2.2(@types/node@20.11.8)(jsdom@24.0.0)(sass@1.70.0):
+    resolution: {integrity: sha512-d5Ouvrnms3GD9USIK36KG8OZ5bEvKEkITFtnGv56HFaSlbItJuYr7hv2Lkn903+AvRAgSixiamozUVfORUekjw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -1969,12 +1969,12 @@ packages:
       jsdom:
         optional: true
     dependencies:
-      '@types/node': 20.11.6
-      '@vitest/expect': 1.2.1
-      '@vitest/runner': 1.2.1
-      '@vitest/snapshot': 1.2.1
-      '@vitest/spy': 1.2.1
-      '@vitest/utils': 1.2.1
+      '@types/node': 20.11.8
+      '@vitest/expect': 1.2.2
+      '@vitest/runner': 1.2.2
+      '@vitest/snapshot': 1.2.2
+      '@vitest/spy': 1.2.2
+      '@vitest/utils': 1.2.2
       acorn-walk: 8.3.2
       cac: 6.7.14
       chai: 4.4.1
@@ -1989,8 +1989,8 @@ packages:
       strip-literal: 1.3.0
       tinybench: 2.6.0
       tinypool: 0.8.2
-      vite: 5.0.12(@types/node@20.11.6)(sass@1.70.0)
-      vite-node: 1.2.1(@types/node@20.11.6)(sass@1.70.0)
+      vite: 5.0.12(@types/node@20.11.8)(sass@1.70.0)
+      vite-node: 1.2.2(@types/node@20.11.8)(sass@1.70.0)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less

--- a/src/page/bulkShow.ts
+++ b/src/page/bulkShow.ts
@@ -289,6 +289,7 @@ export class BulkShow {
 
       if (!pairing.reversed) {
         return {
+          board: pairing.board,
           name1: pairing.white.name,
           name2: pairing.black.name,
           result: game?.result,
@@ -296,6 +297,7 @@ export class BulkShow {
         };
       } else {
         return {
+          board: pairing.board,
           name1: pairing.black.name,
           name2: pairing.white.name,
           result: game?.result.split('').reverse().join(''),
@@ -316,6 +318,7 @@ export class BulkShow {
             'tbody',
             results.map(result =>
               h('tr', { key: result.name1 }, [
+                h('td.mono', result.board),
                 h('td', result.reversed ? '' : 'w'),
                 h('td', result.name1),
                 h('td.mono.text-center.table-secondary', result.result),

--- a/src/page/bulkShow.ts
+++ b/src/page/bulkShow.ts
@@ -8,7 +8,7 @@ import { Stream, readStream } from '../ndJsonStream';
 import { bulkPairing } from '../endpoints';
 import { sleep, ucfirst } from '../util';
 import { loadPlayersFromUrl } from '../view/form';
-import { getPairings, getPlayers, getUrls, saveUrls } from '../scraper/scraper';
+import { Pairing, getPairings, getPlayers, getUrls, saveUrls } from '../scraper/scraper';
 
 type Result = '*' | '1-0' | '0-1' | '½-½' | '+--' | '--+';
 interface FormattedGame {
@@ -26,6 +26,7 @@ export class BulkShow {
   gameStream?: Stream;
   liveUpdate = true;
   fullNames = new Map<Username, string>();
+  crPairings: Pairing[] = [];
   constructor(
     readonly app: App,
     readonly me: Me,
@@ -39,7 +40,7 @@ export class BulkShow {
     this.bulk = await res.json();
     this.redraw();
   };
-  loadGames = async (): Promise<void> => {
+  loadGames = async (forceUpdate: boolean = false): Promise<void> => {
     this.gameStream?.close();
     if (this.bulk) {
       const res = await this.me.httpClient(`${this.app.config.lichessHost}/api/games/export/_ids`, {
@@ -70,7 +71,7 @@ export class BulkShow {
       const empty = this.games.length == 0;
       await sleep((empty ? 1 : 5) * 1000);
       this.liveUpdate = this.liveUpdate && (empty || !!this.games.find(g => g.result === '*'));
-      if (this.liveUpdate) return await this.loadGames();
+      if (this.liveUpdate || forceUpdate) return await this.loadGames();
     }
   };
   static renderClock = (bulk: Bulk) => `${bulk.clock.limit / 60}+${bulk.clock.increment}`;
@@ -111,11 +112,6 @@ export class BulkShow {
   };
   redraw = () => this.app.redraw(this.render());
   render = () => {
-    const playerLink = (player: Player) =>
-      this.lichessLink(
-        '@/' + player.user.name,
-        `${player.user.title ? player.user.title + ' ' : ''}${player.user.name}`,
-      );
     return layout(
       this.app,
       h('div', [
@@ -209,7 +205,7 @@ export class BulkShow {
                                   saveUrls(this.bulk.id, pairingsInput.value, playersInput.value);
                                   this.loadNamesFromChessResults(pairingsInput, playersInput);
 
-                                  this.loadGames();
+                                  this.loadGames(true);
                                 },
                               },
                             },
@@ -233,43 +229,104 @@ export class BulkShow {
             ])
           : h('div.m-5', h('div.spinner-border.d-block.mx-auto', { attrs: { role: 'status' } })),
         ,
-        this.bulk
-          ? h(
-              'table.table.table-striped.table-hover',
-              {
-                hook: { destroy: () => this.onDestroy() },
-              },
-              [
-                h('thead', [
-                  h('tr', [
-                    h('th', this.bulk?.games.length + ' games'),
-                    h('th', 'White'),
-                    h('th'),
-                    h('th', 'Black'),
-                    h('th'),
-                    h('th.text-center', 'Result'),
-                    h('th.text-end', 'Moves'),
-                  ]),
-                ]),
-                h(
-                  'tbody',
-                  this.games.map(g =>
-                    h('tr', { key: g.id }, [
-                      h('td.mono', this.lichessLink(g.id, `#${g.id}`)),
-                      h('td', playerLink(g.players.white)),
-                      h('td', g.fullNames.white),
-                      h('td', playerLink(g.players.black)),
-                      h('td', g.fullNames.black),
-                      h('td.mono.text-center', g.result),
-                      h('td.mono.text-end', g.moves),
-                    ]),
-                  ),
-                ),
-              ],
-            )
-          : undefined,
+        this.bulk ? h('div', [this.renderDefaultView(), this.renderChessResultsView()]) : undefined,
       ]),
     );
+  };
+
+  renderDefaultView = () => {
+    const playerLink = (player: Player) =>
+      this.lichessLink(
+        '@/' + player.user.name,
+        `${player.user.title ? player.user.title + ' ' : ''}${player.user.name}`,
+      );
+    return h(
+      'table.table.table-striped.table-hover',
+      {
+        hook: { destroy: () => this.onDestroy() },
+      },
+      [
+        h('thead', [
+          h('tr', [
+            h('th', this.bulk?.games.length + ' games'),
+            h('th', 'White'),
+            h('th'),
+            h('th', 'Black'),
+            h('th'),
+            h('th.text-center', 'Result'),
+            h('th.text-end', 'Moves'),
+          ]),
+        ]),
+        h(
+          'tbody',
+          this.games.map(g =>
+            h('tr', { key: g.id }, [
+              h('td.mono', this.lichessLink(g.id, `#${g.id}`)),
+              h('td', playerLink(g.players.white)),
+              h('td', g.fullNames.white),
+              h('td', playerLink(g.players.black)),
+              h('td', g.fullNames.black),
+              h('td.mono.text-center', g.result),
+              h('td.mono.text-end', g.moves),
+            ]),
+          ),
+        ),
+      ],
+    );
+  };
+
+  renderChessResultsView = () => {
+    if (this.crPairings.length === 0) {
+      return;
+    }
+
+    const results = this.crPairings.map(pairing => {
+      const game = this.games.find(
+        game =>
+          game.players.white.user.id === pairing.white.lichess?.toLowerCase() &&
+          game.players.black.user.id === pairing.black.lichess?.toLowerCase(),
+      );
+
+      if (!pairing.reversed) {
+        return {
+          name1: pairing.white.name,
+          name2: pairing.black.name,
+          result: game?.result,
+          reversed: pairing.reversed,
+        };
+      } else {
+        return {
+          name1: pairing.black.name,
+          name2: pairing.white.name,
+          result: game?.result.split('').reverse().join(''),
+          reversed: pairing.reversed,
+        };
+      }
+    });
+
+    return h('div.mt-5', [
+      h('h4', 'Chess Results View'),
+      h(
+        'table.table.table-striped.table-hover',
+        {
+          hook: { destroy: () => this.onDestroy() },
+        },
+        [
+          h(
+            'tbody',
+            results.map(result =>
+              h('tr', { key: result.name1 }, [
+                h('td', result.reversed ? '' : 'w'),
+                h('td', result.name1),
+                h('td.mono.text-center.table-secondary', result.result),
+                h('td', result.reversed ? 'w' : ''),
+                h('td', result.name2),
+              ]),
+            ),
+          ),
+        ],
+      ),
+    ]);
   };
 
   private lichessLink = (path: string, text: string) =>
@@ -284,9 +341,9 @@ export class BulkShow {
       const playersUrl = playersInput.value;
 
       const players = playersUrl ? await getPlayers(playersUrl) : undefined;
-      const pairings = await getPairings(pairingsUrl, players);
+      this.crPairings = await getPairings(pairingsUrl, players);
 
-      pairings.forEach(p => {
+      this.crPairings.forEach(p => {
         p.white.lichess && this.fullNames.set(p.white.lichess.toLowerCase(), p.white.name);
         p.black.lichess && this.fullNames.set(p.black.lichess.toLowerCase(), p.black.name);
       });

--- a/src/page/bulkShow.ts
+++ b/src/page/bulkShow.ts
@@ -308,27 +308,21 @@ export class BulkShow {
 
     return h('div.mt-5', [
       h('h4', 'Chess Results View'),
-      h(
-        'table.table.table-striped.table-hover',
-        {
-          hook: { destroy: () => this.onDestroy() },
-        },
-        [
-          h(
-            'tbody',
-            results.map(result =>
-              h('tr', { key: result.name1 }, [
-                h('td.mono', result.board),
-                h('td', result.reversed ? '' : 'w'),
-                h('td', result.name1),
-                h('td.mono.text-center.table-secondary', result.result),
-                h('td', result.reversed ? 'w' : ''),
-                h('td', result.name2),
-              ]),
-            ),
+      h('table.table.table-striped.table-hover', [
+        h(
+          'tbody',
+          results.map(result =>
+            h('tr', { key: result.name1 }, [
+              h('td.mono', result.board),
+              h('td', result.reversed ? '' : 'w'),
+              h('td', result.name1),
+              h('td.mono.text-center.table-secondary', result.result),
+              h('td', result.reversed ? 'w' : ''),
+              h('td', result.name2),
+            ]),
           ),
-        ],
-      ),
+        ),
+      ]),
     ]);
   };
 

--- a/src/scraper/scraper.ts
+++ b/src/scraper/scraper.ts
@@ -10,6 +10,8 @@ export interface Player {
 export interface Pairing {
   white: Player;
   black: Player;
+  /** Whether the pairing should be displayed as "black vs white" instead of "white vs black" */
+  reversed: boolean;
 }
 
 export interface SavedPlayerUrls {
@@ -130,6 +132,7 @@ function parsePairingsForTeamSwiss(html: string): Pairing[] {
           rating: rating2,
           lichess: username2,
         },
+        reversed: false,
       });
     } else if ($(firstDiv).hasClass('FarbesT')) {
       pairings.push({
@@ -143,6 +146,7 @@ function parsePairingsForTeamSwiss(html: string): Pairing[] {
           rating: rating1,
           lichess: username1,
         },
+        reversed: true,
       });
     } else {
       throw new Error('Could not parse Pairings table');
@@ -175,6 +179,7 @@ function parsePairingsForIndividualEvent(html: string, players?: Player[]): Pair
     pairings.push({
       white: players?.find(player => player.name === whiteName) ?? { name: whiteName },
       black: players?.find(player => player.name === blackName) ?? { name: blackName },
+      reversed: false,
     });
   });
 

--- a/src/scraper/scraper.ts
+++ b/src/scraper/scraper.ts
@@ -12,6 +12,7 @@ export interface Pairing {
   black: Player;
   /** Whether the pairing should be displayed as "black vs white" instead of "white vs black" */
   reversed: boolean;
+  board: string;
 }
 
 export interface SavedPlayerUrls {
@@ -100,6 +101,7 @@ function parsePairingsForTeamSwiss(html: string): Pairing[] {
       return;
     }
 
+    const boardNumber = $(element).children().eq(0).text().trim();
     const white = $(element).find('table').find('div.FarbewT').parentsUntil('table').last().text().trim();
     const black = $(element).find('table').find('div.FarbesT').parentsUntil('table').last().text().trim();
 
@@ -133,6 +135,7 @@ function parsePairingsForTeamSwiss(html: string): Pairing[] {
           lichess: username2,
         },
         reversed: false,
+        board: boardNumber,
       });
     } else if ($(firstDiv).hasClass('FarbesT')) {
       pairings.push({
@@ -147,6 +150,7 @@ function parsePairingsForTeamSwiss(html: string): Pairing[] {
           lichess: username1,
         },
         reversed: true,
+        board: boardNumber,
       });
     } else {
       throw new Error('Could not parse Pairings table');
@@ -173,6 +177,7 @@ function parsePairingsForIndividualEvent(html: string, players?: Player[]): Pair
       return;
     }
 
+    const boardNumber = $(element).children().eq(0).text().trim();
     const whiteName = $(element).children().eq(headers.indexOf('Name')).text().trim();
     const blackName = $(element).children().eq(headers.lastIndexOf('Name')).text().trim();
 
@@ -180,6 +185,7 @@ function parsePairingsForIndividualEvent(html: string, players?: Player[]): Pair
       white: players?.find(player => player.name === whiteName) ?? { name: whiteName },
       black: players?.find(player => player.name === blackName) ?? { name: blackName },
       reversed: false,
+      board: boardNumber,
     });
   });
 

--- a/src/scraper/tests/scrape.test.ts
+++ b/src/scraper/tests/scrape.test.ts
@@ -55,6 +55,7 @@ describe('fetch pairings', () => {
           rating: 1985,
         },
         reversed: false,
+        board: '1.1',
       },
       {
         black: {
@@ -68,6 +69,7 @@ describe('fetch pairings', () => {
           rating: 0,
         },
         reversed: true,
+        board: '1.2',
       },
       {
         black: {
@@ -81,6 +83,7 @@ describe('fetch pairings', () => {
           rating: 1900,
         },
         reversed: false,
+        board: '1.3',
       },
       {
         black: {
@@ -94,6 +97,7 @@ describe('fetch pairings', () => {
           rating: 0,
         },
         reversed: true,
+        board: '1.4',
       },
       {
         black: {
@@ -107,6 +111,7 @@ describe('fetch pairings', () => {
           rating: 0,
         },
         reversed: false,
+        board: '2.1',
       },
       {
         black: {
@@ -120,6 +125,7 @@ describe('fetch pairings', () => {
           rating: 2070,
         },
         reversed: true,
+        board: '2.2',
       },
       {
         black: {
@@ -133,6 +139,7 @@ describe('fetch pairings', () => {
           rating: 1270,
         },
         reversed: false,
+        board: '2.3',
       },
       {
         black: {
@@ -146,6 +153,7 @@ describe('fetch pairings', () => {
           rating: 1111,
         },
         reversed: true,
+        board: '2.4',
       },
     ]);
   });
@@ -166,6 +174,7 @@ describe('fetch pairings', () => {
         lichess: undefined,
       },
       reversed: false,
+      board: '1.1',
     });
     expect(pairings[1]).toEqual({
       black: {
@@ -179,6 +188,7 @@ describe('fetch pairings', () => {
         lichess: undefined,
       },
       reversed: true,
+      board: '1.2',
     });
   });
 
@@ -194,6 +204,7 @@ describe('fetch pairings', () => {
         name: 'Galaktionov, Artem',
       },
       reversed: false,
+      board: '1',
     });
   });
 
@@ -209,6 +220,7 @@ describe('fetch pairings', () => {
         name: 'Mammadzada, Gunay',
       },
       reversed: false,
+      board: '1',
     });
   });
 
@@ -236,6 +248,7 @@ describe('fetch pairings', () => {
         lichess: 'test-gunay',
       },
       reversed: false,
+      board: '1',
     });
   });
 });

--- a/src/scraper/tests/scrape.test.ts
+++ b/src/scraper/tests/scrape.test.ts
@@ -54,6 +54,7 @@ describe('fetch pairings', () => {
           name: 'Testing, Test',
           rating: 1985,
         },
+        reversed: false,
       },
       {
         black: {
@@ -66,6 +67,7 @@ describe('fetch pairings', () => {
           name: 'Trevlar, Someone',
           rating: 0,
         },
+        reversed: true,
       },
       {
         black: {
@@ -78,6 +80,7 @@ describe('fetch pairings', () => {
           name: 'Another, Test',
           rating: 1900,
         },
+        reversed: false,
       },
       {
         black: {
@@ -90,6 +93,7 @@ describe('fetch pairings', () => {
           name: 'Testing, Tester',
           rating: 0,
         },
+        reversed: true,
       },
       {
         black: {
@@ -102,6 +106,7 @@ describe('fetch pairings', () => {
           name: 'Wait, Theophilus',
           rating: 0,
         },
+        reversed: false,
       },
       {
         black: {
@@ -114,6 +119,7 @@ describe('fetch pairings', () => {
           name: 'YetSomeoneElse, Lilly',
           rating: 2070,
         },
+        reversed: true,
       },
       {
         black: {
@@ -126,6 +132,7 @@ describe('fetch pairings', () => {
           name: 'Gkizi, Konst',
           rating: 1270,
         },
+        reversed: false,
       },
       {
         black: {
@@ -138,6 +145,7 @@ describe('fetch pairings', () => {
           name: 'Also, Unknown',
           rating: 1111,
         },
+        reversed: true,
       },
     ]);
   });
@@ -157,6 +165,7 @@ describe('fetch pairings', () => {
         rating: 2789,
         lichess: undefined,
       },
+      reversed: false,
     });
     expect(pairings[1]).toEqual({
       black: {
@@ -169,6 +178,7 @@ describe('fetch pairings', () => {
         rating: 2368,
         lichess: undefined,
       },
+      reversed: true,
     });
   });
 
@@ -183,6 +193,7 @@ describe('fetch pairings', () => {
       black: {
         name: 'Galaktionov, Artem',
       },
+      reversed: false,
     });
   });
 
@@ -197,6 +208,7 @@ describe('fetch pairings', () => {
       black: {
         name: 'Mammadzada, Gunay',
       },
+      reversed: false,
     });
   });
 
@@ -223,6 +235,7 @@ describe('fetch pairings', () => {
         name: 'Mammadzada, Gunay',
         lichess: 'test-gunay',
       },
+      reversed: false,
     });
   });
 });


### PR DESCRIPTION
When a Pairings URL is entered and loaded, a secondary table appears under the results table.

That table is formatted the same way it will appear in Swiss Manager (row order + players in correct columns)

![image](https://github.com/lichess-org/api-ui/assets/271432/a2c0bdbe-1ed1-449f-8e37-40d34e959ed2)
