### PR TITLE
Fix openChallenge after API response got flattened

### DIFF
--- a/src/page/openChallenge.ts
+++ b/src/page/openChallenge.ts
@@ -7,13 +7,12 @@ import layout from '../view/layout';
 import { card, copyInput } from '../view/util';
 
 interface Result {
-  challenge: {
-    id: string;
-    url: string;
-    open: {
-      userIds?: [string, string];
-    };
+  id: string;
+  url: string;
+  open: {
+    userIds?: [string, string];
   };
+
   urlWhite: string;
   urlBlack: string;
 }
@@ -89,7 +88,7 @@ export class OpenChallenge {
     ]);
 
   private renderResult = (result: Result) => {
-    const c = result.challenge;
+    const c = result;
     return card(
       c.id,
       ['Challenge #', c.id],

--- a/src/page/openChallenge.ts
+++ b/src/page/openChallenge.ts
@@ -12,7 +12,6 @@ interface Result {
   open: {
     userIds?: [string, string];
   };
-
   urlWhite: string;
   urlBlack: string;
 }


### PR DESCRIPTION
Restore the Links and Challenge id, after the API response got [flattened](https://github.com/lichess-org/api/pull/354).  

![image](https://github.com/lichess-org/api-ui/assets/19399877/317b8950-3f36-4fbc-9152-04b894d13058)
